### PR TITLE
Add parentheses for Python 3 print function in ester-check-models

### DIFF
--- a/test/models/test_models.in
+++ b/test/models/test_models.in
@@ -135,9 +135,9 @@ par1d = datadir+"1d.par"
 par2d = datadir+"2d.par"
 
 def fail(cmd):
-    print "[Failed]"
-    print "Directory was: `" + check_dir + "'"
-    print "Command was: '" + cmd + "'"
+    print("[Failed]")
+    print("Directory was: `" + check_dir + "'")
+    print("Command was: '" + cmd + "'")
     sys.exit(1)
 
 def runCheck(check):
@@ -149,15 +149,15 @@ def runCheck(check):
     if check['output'] != "":
         run_cmd += " -o " + check['output']
 
-    print check['name']
-    print "  run:\t\t", # we need the last comma to avoid newline
+    print(check['name'])
+    print("  run:\t\t", end='')
     sys.stdout.flush()
 
     devnull = open("/dev/null", "w")
     code = call(run_cmd.split(), stdout=devnull)
     devnull.close()
     if code == 0:
-        print "[OK]"
+        print("[OK]")
     else:
         fail(run_cmd)
 
@@ -165,7 +165,7 @@ def runCheck(check):
     fin = open(check['template'], "r")
     checkFile = check['output']+".check"
 
-    print "  output:\t", # we need the last comma to avoid newline
+    print("  output:\t", end='')
     sys.stdout.flush()
 
     fout = open(checkFile, "w")
@@ -173,16 +173,16 @@ def runCheck(check):
     fin.close()
     fout.close()
     if code == 0:
-        print "[OK]"
+        print("[OK]")
     else:
         fail(run_cmd)
 
-    print "  compare:\t", # we need the last comma to avoid newline
+    print("  compare:\t", end='')
     sys.stdout.flush()
 
     fcmp = compare(checkFile, check['ref'])
     if fcmp == True:
-        print "[OK]"
+        print("[OK]")
     else:
         fail(run_cmd)
 


### PR DESCRIPTION
I recently installed ESTER successfully using the instructions in the top-level `INSTALL` file, i.e. in the ESTER folder,
```
$ ./bootstrap
$ ./configure --prefix=~/.local LIBS="-lpython3.10"
$ make -j 4
$ make install
```
worked.

I then noticed that the `ester-check-models` script returned syntax errors because there weren't parentheses in some of the `print` statements, which are required for Python 3. e.g.,
```
$ ester-check-models
  File "/home/wball/.local/bin/ester-check-models", line 138
    print "[Failed]"
    ^^^^^^^^^^^^^^^^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
```
I think I correctly inferred how the `ester-check-models` script is generated and have modified that file to include the missing parentheses.

The [Wiki says](https://github.com/ester-project/ester/wiki/Contributing) I should open the PR against `dev`, rather than `master`, but `master` has been updated more recently and the Wiki was last modified in 2015. I'm happy to change the target to `dev`.