### PR TITLE
Logging update

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -12,63 +12,115 @@
 #include "debug.h"
 #endif
 
-#ifdef __GNUG__
-#define _print_stack()   { \
-    print_stack(); \
-}
-#else
-#define _print_stack()   { }
-#endif
-
-#ifdef DEBUG
-#define ester_err(...) do { \
-    LOGE("Error at %s:%d: ", __FILE__, __LINE__); \
-    LOGE(__VA_ARGS__); \
-    LOGE("\n"); \
-    print_stack(); \
-    throw runtime_exception(); \
-} while(0)
-#else
-#define ester_err(...) do { \
-    LOGE("Error: "); \
-    LOGE(__VA_ARGS__); \
-    LOGE("\n"); \
-    print_stack(); \
-    exit(EXIT_FAILURE); \
-} while(0)
-#endif
-
-#ifdef DEBUG
-#define ester_warn(...) do { \
-    LOGW("Warning at %s:%d: ", __FILE__, __LINE__); \
-    LOGW(__VA_ARGS__); \
-    LOGW("\n"); \
-} while(0)
-#else
-#define ester_warn(...) do { \
-    LOGW("Warning: "); \
-    LOGW(__VA_ARGS__); \
-    LOGW("\n"); \
-} while(0)
-#endif
-
-#ifdef DEBUG
-#define ester_debug(...) do { \
-    fprintf(stderr, __VA_ARGS__); \
-} while (0)
-#else
-#define ester_debug(...) do {} while (0)
-#endif
-
-bool isHDF5Name(const char *fileName);
-
 #define RED "\033[0;31m"
 #define GREEN "\033[0;32m"
 #define YELLOW "\033[0;33m"
 #define RESET "\033[0;0m"
 
-#define LOGI(...)   { printf(GREEN); printf(__VA_ARGS__); printf(RESET); fflush(stdout); }
-#define LOGW(...)   { fprintf(stderr, YELLOW); fprintf(stderr, __VA_ARGS__); fprintf(stderr, RESET); }
-#define LOGE(...)   { fprintf(stderr, RED); fprintf(stderr, __VA_ARGS__); fprintf(stderr, RESET); }
+/*
+Define utility log functions:
+ester_debug|info|warn|err|critical
+
+`ester_debug`:
+print to stderr in DEBUG
+none else
+
+`ester_debug`:
+prefixed with green "Info"
+print to stdout in both modes
+
+`ester_warn`:
+prefixed with yellow "Warning:"
+print to stderr
++ indicate line and file in DEBUG
+
+`ester_err`:
+same as `ester_warn` with red "Error:"
++ print stack in DEBUG
+
+`ester_critical`:
+same as `ester_err` with red "CRITICAL:"
++ exit program or throw eception
+*/
+
+#ifdef DEBUG
+#define ester_debug(...) do { \
+    fprintf(stderr, __VA_ARGS__); \
+} while (0)
+
+#define ester_info(...) do { \
+    printf(GREEN); \
+    printf("Info: "); \
+    printf(RESET); \
+    printf(__VA_ARGS__); \
+    fflush(stdout); \
+} while (0)
+
+#define ester_warn(...) do { \
+    fprintf(stderr, YELLOW); \
+    fprintf(stderr, "Warning at %s:%d: ", __FILE__, __LINE__); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+} while(0)
+
+#define ester_err(...) do { \
+    fprintf(stderr, RED); \
+    fprintf(stderr, "Error at %s:%d: ", __FILE__, __LINE__); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+    print_stack();
+} while(0)
+
+#define ester_critical(...) do { \
+    fprintf(stderr, RED); \
+    fprintf(stderr, "CRITICAL at %s:%d: ", __FILE__, __LINE__); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+    print_stack();
+    throw runtime_exception(); \
+} while(0)
+
+#else // DEBUG
+#define ester_debug(...) do {} while (0)
+
+#define ester_info(...) do { \
+    printf(GREEN); \
+    printf("Info: "); \
+    printf(RESET); \
+    printf(__VA_ARGS__); \
+    fflush(stdout); \
+} while (0)
+
+#define ester_warn(...) do { \
+    fprintf(stderr, YELLOW); \
+    fprintf(stderr, "Warning: "); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+} while(0)
+
+#define ester_err(...) do { \
+    fprintf(stderr, RED); \
+    fprintf(stderr, "Error: "); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+} while(0)
+
+#define ester_critical(...) do { \
+    fprintf(stderr, RED); \
+    fprintf(stderr, "CRITICAL: "); \
+    fprintf(stderr, RESET); \
+    fprintf(stderr, __VA_ARGS__); \
+    fprintf(stderr, "\n"); \
+    exit(EXIT_FAILURE); \
+} while(0)
+
+#endif // DEBUG
+
+bool isHDF5Name(const char *fileName);
 
 #endif // ESTER_UTILS_H

--- a/src/main/ester-info.cpp
+++ b/src/main/ester-info.cpp
@@ -20,6 +20,6 @@ int main(int argc,char *argv[]) {
         return 0;
     }
 
-    ester_err("Unknown file format");
+    ester_critical("Unknown file format");
     return 1;
 }

--- a/src/main/gen_output.cpp
+++ b/src/main/gen_output.cpp
@@ -25,7 +25,7 @@ int main(int argc,char *argv[]) {
 	if(!m1d.read(input_file, 1)) output2d(m1d);
 	else if (!m2d.read(input_file)) output2d(m2d);
 	else {
-		ester_err("Error reading input file: %s",input_file);
+		ester_critical("Error reading input file: %s",input_file);
 		return 1;
 	}
 	
@@ -589,8 +589,8 @@ void write(const star2d &A,char *var,char *fmt) {
 			fwrite(&d,sizeof(double),1,stdout);
 		}
 	} else {
-		ester_err("Unknown variable %s", var);
-		exit(1);
+		ester_critical("Unknown variable %s", var);
+		exit(1); // Useless because ester_critical already exit
 	}
 }
 

--- a/src/main/read_config.cpp
+++ b/src/main/read_config.cpp
@@ -129,5 +129,5 @@ int configuration::check_arg(const char *arg,const char *val) {
 }
 
 void configuration::missing_argument(const char *arg) {
-	ester_err("Error: Argument to '%s' missing", arg);
+	ester_critical("Error: Argument to '%s' missing", arg);
 }

--- a/src/main/star1d.cpp
+++ b/src/main/star1d.cpp
@@ -48,7 +48,7 @@ int main(int argc,char *argv[]) {
     solver *op;
 
     if(A.init(config.input_file,config.param_file,argc,argv)) {
-        ester_err("Could not initialize star");
+        ester_critical("Could not initialize star");
         return 1;
     }
 

--- a/src/main/star2d.cpp
+++ b/src/main/star2d.cpp
@@ -39,7 +39,7 @@ int main(int argc,char *argv[]) {
 	solver *op;
 	
 	if(A.init(config.input_file,config.param_file,argc,argv)) {
-        ester_err("Could not initialize star");
+		ester_critical("Could not initialize star");
         return 1;
     }
 	

--- a/src/main/star_evol.cpp
+++ b/src/main/star_evol.cpp
@@ -29,20 +29,17 @@ int main(int argc,char *argv[]) {
 			else Xcmin=atof(val);
 		} else err_code=1;
 		if(err_code==1) {
-			fprintf(stderr,"Unknown parameter %s\n",arg);
-			exit(1);
+			ester_critical("Unknown parameter %s", arg);
 		}
 		if(err_code==2) {
-			fprintf(stderr,"Argument to %s missing\n",arg);
-			exit(1);
+			ester_critical("Argument to %s missing", arg);
 		}
 		cmd.ack(arg,val);
 	}
 	cmd.close();
 	
 	if(*config.input_file==0) {
-		fprintf(stderr,"Must specify an input file\n");
-		exit(1);
+		ester_critical("Must specify an input file");
 	}
 	if(*config.output_file==0) {
 		strcpy(config.input_file,config.output_file);
@@ -53,8 +50,7 @@ int main(int argc,char *argv[]) {
 	if(A.read(config.input_file)) {
 		star1d A1d;
 		if(A1d.read(config.input_file)) {
-			fprintf(stderr,"Error reading input file %s\n",config.input_file);
-			exit(1);
+			ester_critical("Error reading input file %s", config.input_file);
 		}
 		A=A1d;
 	}

--- a/src/main/vtk.cpp
+++ b/src/main/vtk.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
         fclose(f);
     }
     else {
-        fprintf(stderr, "Couldn't open model %s (is is a 2D model?)\n", input_model);
+        ester_err("Couldn't open model %s (is is a 2D model?)", input_model);
         return 1;
     }
 

--- a/src/mapping/mapping.cpp
+++ b/src/mapping/mapping.cpp
@@ -287,12 +287,12 @@ matrix mapping::stream(const matrix &Fz) const {
 matrix mapping::eval(const matrix &y,const matrix &ri, const matrix &thi,int parity) const {
 
 	if(ri.nrows()!=thi.nrows()||ri.ncols()!=thi.ncols()) {
-		ester_err("(mapping.eval) Matrix dimensions must agree");
-		exit(1);
+		ester_critical("(mapping.eval) Matrix dimensions must agree");
+		exit(1); // Useless because ester_critical already exit
 	}
 	if(y.nrows()!=gl.N||y.ncols()!=leg.npts) {
-		ester_err("(mapping.eval) Matrix dimensions must agree");
-		exit(1);
+		ester_critical("(mapping.eval) Matrix dimensions must agree");
+		exit(1); // Useless because ester_critical already exit
 	}
 
 	matrix yi(ri.nrows(),ri.ncols());
@@ -307,9 +307,9 @@ matrix mapping::eval(const matrix &y,const matrix &ri, const matrix &thi,int par
 		if(zi-1>-1e-10&&zi-1<1e-10) zi=1;
 		if(zi<1e-10&&zi>-1e-10) zi=0;
 		if(zi>1||zi<0) {
-			ester_err("(mapping.eval) Coordinates (r,theta)=(%f,%f) are out of bounds",
+			ester_critical("(mapping.eval) Coordinates (r,theta)=(%f,%f) are out of bounds",
 				ri(i),thi(i));
-			exit(1);
+			exit(1); // Useless because ester_critical already exit
 		}
 		int fin=0,nit=0;
 		if(zi==0||zi==1) fin=99;
@@ -319,8 +319,8 @@ matrix mapping::eval(const matrix &y,const matrix &ri, const matrix &thi,int par
 			if(fabs(dzi)<1e-10) fin++;
 			nit++;
 			if(nit>100) {
-				ester_err("(mapping.eval) Failed to converge");
-				exit(1);
+				ester_critical("(mapping.eval) Failed to converge");
+				exit(1); // Useless because ester_critical already exit
 			}
 			zi+=dzi;
 		}
@@ -336,8 +336,8 @@ matrix mapping::zeta_to_r(const matrix &z) const {
 	matrix rr(z.nrows(),z.ncols());
 
 	if(z.ncols()!=leg.npts) {
-		ester_err("(mapping.zeta_to_r) Matrix must have nth columns");
-		exit(1);
+		ester_critical("(mapping.zeta_to_r) Matrix must have nth columns");
+		exit(1); // Useless because ester_critical already exit
 	}
 
 	for(int j=0;j<leg.npts;j++) {

--- a/src/mapping/remapper.cpp
+++ b/src/mapping/remapper.cpp
@@ -86,8 +86,8 @@ void remapper::set_fixed(int idom_new,int idom_old) {
 
 	fixed[idom_new]=idom_old;
 	if(idom_old>map.ndomains) {
-		ester_err("(remapper) Index exceeds number of domains");
-		exit(1);
+		ester_critical("(remapper) Index exceeds number of domains");
+		exit(1); // Useless because ester_critical already exit
 	}
 
 }
@@ -182,18 +182,18 @@ matrix remapper::interp_ex(const matrix &y,int parity) {
 void remapper::remap() {
 
 	if(ndomains!=map.ndomains&&!changed_npts) {
-		ester_err("(remapper) Should specify number of points in each domain");
-		exit(1);
+		ester_critical("(remapper) Should specify number of points in each domain");
+		exit(1); // Useless because ester_critical already exit
 	}
 
 	if(ndomains!=map.ndomains&&!redist) {
-		ester_err("(remapper) Should specify domain boundaries");
-		exit(1);
+		ester_critical("(remapper) Should specify domain boundaries");
+		exit(1); // Useless because ester_critical already exit
 	}
 	
 	if(R.nrows()!=ndomains+1) {
-		ester_err("(remapper) Incorrect size of boundary matrix R");
-		exit(1);
+		ester_critical("(remapper) Incorrect size of boundary matrix R");
+		exit(1); // Useless because ester_critical already exit
 	}
 	remapped=1;
 	
@@ -206,8 +206,8 @@ void remapper::remap() {
 	
 	if(R.ncols()!=nt) {
 		if(R.ncols()!=map.nt) {
-			ester_err("Error: (remapper) Incorrect size of boundary matrix R");
-			exit(1);
+			ester_critical("Error: (remapper) Incorrect size of boundary matrix R");
+			exit(1); // Useless because ester_critical already exit
 		}
 		R=map.leg.eval_00(R,map_new.th);
 	}
@@ -274,8 +274,8 @@ void remapper::remap() {
 			zi+=dzi;
 			nit++;
 			if(nit>100) {
-				ester_err("(remapper) No convergence in remap()");
-				exit(1);
+				ester_critical("(remapper) No convergence in remap()");
+				exit(1); // Useless because ester_critical already exit
 			}
 		}
 		zmap.setcol(j,zi);

--- a/src/matrix/mat_math.cpp
+++ b/src/matrix/mat_math.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "matrix.h"
+#include "utils.h"
 
 
 matrix cos(const matrix &a) {

--- a/src/matrix/mat_math.cpp
+++ b/src/matrix/mat_math.cpp
@@ -253,9 +253,8 @@ matrix atan2(const matrix &a,const matrix &b) {
     int i,N;
     
     if( (b.nf!=a.nf) || (b.nc!=a.nc) ) {
-		fprintf(stderr,"ERROR: (matrix.atan2) Dimensions must agree\n");
-		exit(1);
-	}
+        ester_critical("(matrix.atan2) Dimensions must agree");
+    }
     
     N=a.nc*a.nf;
     
@@ -300,9 +299,8 @@ matrix pow(const matrix &a,const matrix &b) {
     int i,N;
     
     if( (b.nf!=a.nf) || (b.nc!=a.nc) ) {
-		fprintf(stderr,"ERROR: (matrix.pow) Dimensions must agree\n");
-		exit(1);
-	}
+        ester_critical("(matrix.pow) Dimensions must agree");
+    }
     
     N=a.nc*a.nf;
     

--- a/src/matrix/mat_spec.cpp
+++ b/src/matrix/mat_spec.cpp
@@ -23,8 +23,8 @@ extern "C" {
 matrix matrix::operator,(const matrix &a) const {
 
     if(nc!=a.nf) {
-        ester_err("(matrix.,) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.,) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     matrix res(nf,a.nc);
@@ -41,19 +41,19 @@ matrix matrix::solve(matrix b) const {
     matrix lu(*this);
 
     if(nf!=b.nf) {
-        ester_err("(matrix.solve) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.solve) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
     if(nf!=nc) {
-        ester_err("(matrix.solve) Matrix must be square");
-        exit(1);
+        ester_critical("(matrix.solve) Matrix must be square");
+        exit(1); // Useless because ester_critical already exit
     }
 
     enable_sigfpe();
     dgetrf_(&lu.nf,&lu.nc,lu.p,&lu.nf,ipiv,&info);
     if(info>0) {
         printf("Matrix is singular (%d)\n",info);
-        exit(1);
+        exit(1); // Useless because ester_critical already exit
     }
     dgetrs_(&trans,&lu.nf,&b.nc,lu.p,&lu.nf,ipiv,b.p,&b.nf,&info);
     disable_sigfpe();
@@ -69,14 +69,14 @@ matrix matrix::inv() const {
     double *work,w;
 
     if(nf!=nc) {
-        ester_err("(matrix.inv) Matrix must be square");
-        exit(1);
+        ester_critical("(matrix.inv) Matrix must be square");
+        exit(1); // Useless because ester_critical already exit
     }
 
     dgetrf_(&res.nf,&res.nc,res.p,&res.nf,ipiv,&info);
     if(info>0) {
         printf("Matrix is singular (%d)\n",info);
-        exit(1);
+        exit(1); // Useless because ester_critical already exit
     }
     dgetri_(&res.nf,res.p,&res.nf,ipiv,&w,&lwork,&info);
     lwork = (int) round(w);

--- a/src/matrix/matrix.cpp
+++ b/src/matrix/matrix.cpp
@@ -19,13 +19,13 @@ matrix::matrix(int nfil, int ncol) {
     unsigned tam;
 
     if(nfil<0||ncol<0) {
-        ester_err("Can't create matrix with negative size");
+        ester_critical("Can't create matrix with negative size");
     }
     if(nfil==0) {
-        ester_err("Number of rows can't be zero");
+        ester_critical("Number of rows can't be zero");
     }
     if(ncol==0) {
-        ester_err("Number of columns can't be zero");
+        ester_critical("Number of columns can't be zero");
     }
     nf=nfil;
     nc=ncol;
@@ -86,16 +86,16 @@ matrix &matrix::dim(int nfil, int ncol) {
     unsigned tam;
 
     if(nfil<0||ncol<0) {
-        ester_err("Can't create matrix with negative size");
-        exit(1);
+        ester_critical("Can't create matrix with negative size");
+        exit(1); // Useless because ester_critical already exit
     }
     if(nfil==0) {
-        ester_err("Number of rows can't be zero");
-        exit(1);
+        ester_critical("Number of rows can't be zero");
+        exit(1); // Useless because ester_critical already exit
     }
     if(ncol==0) {
-        ester_err("Number of columns can't be zero");
-        exit(1);
+        ester_critical("Number of columns can't be zero");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nfil*ncol!=nf*nc) {
@@ -121,21 +121,21 @@ matrix &matrix::dim(int nfil, int ncol) {
 matrix &matrix::redim(int nfil, int ncol) {
 
     if(nfil<0||ncol<0) {
-        ester_err("Can't create matrix with negative size");
-        exit(1);
+        ester_critical("Can't create matrix with negative size");
+        exit(1); // Useless because ester_critical already exit
     }
     if(nfil==0) {
-        ester_err("Number of rows can't be zero");
-        exit(1);
+        ester_critical("Number of rows can't be zero");
+        exit(1); // Useless because ester_critical already exit
     }
     if(ncol==0) {
-        ester_err("Number of columns can't be zero");
-        exit(1);
+        ester_critical("Number of columns can't be zero");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nfil*ncol!=nf*nc) {
-        ester_err("matrix.redim: Number of elements doesn't match");
-        exit(1);
+        ester_critical("matrix.redim: Number of elements doesn't match");
+        exit(1); // Useless because ester_critical already exit
     }
     nf=nfil;nc=ncol;
 
@@ -162,8 +162,8 @@ double &matrix::operator()(int ifil, int icol) {
     if(ifil<0) ifil+=nf;
     if(icol<0) icol+=nc;
     if(ifil>=nf||ifil<0||icol>=nc||icol<0) {
-        ester_err("Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     return *(p+icol*nf+ifil);
 
@@ -175,8 +175,8 @@ double &matrix::operator()(int ielem) {
 
     if(ielem<0) ielem+=nf*nc;
     if(ielem>=nf*nc||ielem<0) {
-        ester_err("Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     return *(p+ielem);
 
@@ -189,8 +189,8 @@ const double &matrix::operator()(int ifil, int icol) const {
     if(ifil<0) ifil+=nf;
     if(icol<0) icol+=nc;
     if(ifil>=nf||ifil<0||icol>=nc||icol<0) {
-        ester_err("Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     return *(p+icol*nf+ifil);
 
@@ -202,8 +202,8 @@ const double &matrix::operator()(int ielem) const {
 
     if(ielem<0) ielem+=nf*nc;
     if(ielem>=nf*nc||ielem<0) {
-        ester_err("Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     return *(p+ielem);
 
@@ -322,8 +322,8 @@ matrix matrix::operator+(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1 && a.nf!=1 && nf!=a.nf) || (nc!=1 && a.nc!=1 && nc!=a.nc) ) {
-        ester_err("(matrix.+) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.+) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf; // This cannot happen
@@ -374,8 +374,8 @@ matrix matrix::operator-(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.-) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.-) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -451,8 +451,8 @@ matrix matrix::operator*(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.*) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.*) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -504,8 +504,8 @@ matrix matrix::operator/(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix./) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix./) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -568,8 +568,8 @@ matrix matrix::operator==(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.==) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.==) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -620,8 +620,8 @@ matrix matrix::operator!=(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.!=) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.!=) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -671,8 +671,8 @@ matrix matrix::operator>(const matrix &a) const{
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.>) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.>) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -736,8 +736,8 @@ matrix matrix::operator>=(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.>=) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.>=) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -801,8 +801,8 @@ matrix matrix::operator||(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.||) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.||) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -853,8 +853,8 @@ matrix matrix::operator&&(const matrix &a) const {
     int i, j, resnf, resnc, N;
 
     if( (nf!=1&&a.nf!=1&&nf!=a.nf) || (nc!=1&&a.nc!=1&&nc!=a.nc) ) {
-        ester_err("(matrix.&&) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.&&) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     if(nf>a.nf) resnf=nf;
@@ -1050,8 +1050,8 @@ const matrix matrix::row(int ifil) const {
 
     if(ifil<0) ifil+=nf;
     if(ifil<0||ifil>=nf) {
-        ester_err("(matrix.row) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.row) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
 
     pi=p+ifil;
@@ -1069,12 +1069,12 @@ matrix &matrix::setrow(int ifil, const matrix &a) {
 
     if(ifil<0) ifil+=nf;
     if(ifil<0||ifil>=nf) {
-        ester_err("(matrix.setrow) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.setrow) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     if(a.nf>1||a.nc!=nc) {
-        ester_err("(matrix.setrow) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.setrow) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     pi=p+ifil;
@@ -1094,8 +1094,8 @@ const matrix matrix::col(int icol) const {
 
     if(icol<0) icol+=nc;
     if(icol<0||icol>=nc) {
-        ester_err("(matrix.col) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.col) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
 
     pi=p+icol*nf;
@@ -1113,12 +1113,12 @@ matrix &matrix::setcol(int icol, const matrix &a) {
 
     if(icol<0) icol+=nc;
     if(icol<0||icol>=nc) {
-        ester_err("(matrix.setcol) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.setcol) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     if(a.nc>1||a.nf!=nf) {
-        ester_err("(matrix.setcol) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.setcol) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     pi=p+icol*nf;
@@ -1138,8 +1138,8 @@ const matrix matrix::block(int ifil1, int ifil2, int icol1, int icol2) const {
     if(icol2<0) icol2+=nc;
 
     if(ifil1<0||ifil1>=nf||ifil2<0||ifil2>=nf||icol1<0||icol1>=nc||icol2<0||icol2>=nc) {
-        ester_err("(matrix.block) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.block) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
 
     matrix res(ifil2-ifil1+1, icol2-icol1+1);
@@ -1166,8 +1166,8 @@ const matrix matrix::block_step(int ifil1, int ifil2, int dfil, int icol1, int i
     if(icol2<0) icol2+=nc;
 
     if(ifil1<0||ifil1>=nf||ifil2<0||ifil2>=nf||icol1<0||icol1>=nc||icol2<0||icol2>=nc) {
-        ester_err("(matrix.block_step) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.block_step) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
 
     matrix res((int) floor((ifil2-ifil1)/dfil)+1,
@@ -1194,12 +1194,12 @@ matrix &matrix::setblock(int ifil1, int ifil2, int icol1, int icol2, const matri
     if(icol2<0) icol2+=nc;
 
     if(ifil1<0||ifil1>=nf||ifil2<0||ifil2>=nf||icol1<0||icol1>=nc||icol2<0||icol2>=nc) {
-        ester_err("(matrix.setblock) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.setblock) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     if(a.nf!=ifil2-ifil1+1||a.nc!=icol2-icol1+1) {
-        ester_err("(matrix.setblock) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.setblock) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     double *pi, *pa;
@@ -1226,12 +1226,12 @@ matrix &matrix::setblock_step(int ifil1, int ifil2, int dfil, int icol1, int ico
     if(icol2<0) icol2+=nc;
 
     if(ifil1<0||ifil1>=nf||ifil2<0||ifil2>=nf||icol1<0||icol1>=nc||icol2<0||icol2>=nc) {
-        ester_err("(matrix.setblock_step) Index exceeds matrix dimensions");
-        exit(1);
+        ester_critical("(matrix.setblock_step) Index exceeds matrix dimensions");
+        exit(1); // Useless because ester_critical already exit
     }
     if(a.nf!=floor((ifil2-ifil1)/dfil)+1||a.nc!=floor((icol2-icol1)/dcol)+1) {
-        ester_err("(matrix.setblock_step) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.setblock_step) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     double *pi, *pa;
@@ -1256,17 +1256,17 @@ matrix matrix::concatenate(const matrix &a, int dir) const {
 
     if(dir==0) {
         if(a.nc!=nc) {
-            ester_err("(matrix.concatenate) Dimensions must agree (%d != %d)",
+            ester_critical("(matrix.concatenate) Dimensions must agree (%d != %d)",
                     a.nc, nc);
-            exit(1);
+            exit(1); // Useless because ester_critical already exit
         }
         res.dim(nf+a.nf, nc);
         res.setblock(0, nf-1, 0, -1, *this);
         res.setblock(nf, a.nf+nf-1, 0, -1, a);
     } else {
         if(a.nf!=nf) {
-            ester_err("(matrix.concatenate) Dimensions must agree");
-            exit(1);
+            ester_critical("(matrix.concatenate) Dimensions must agree");
+            exit(1); // Useless because ester_critical already exit
         }
         res.dim(nf, nc+a.nc);
         res.setblock(0, -1, 0, nc-1, *this);
@@ -1467,8 +1467,8 @@ double mean(const matrix &a) {
 matrix max(const matrix &a, const matrix &b) {
 
     if( (b.nf!=a.nf) || (b.nc!=a.nc) ) {
-        ester_err("(matrix.max) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.max) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     matrix res(a.nf, a.nc);
@@ -1499,8 +1499,8 @@ matrix max(double n, const matrix &a) {
 matrix min(const matrix &a, const matrix &b) {
 
     if( (b.nf!=a.nf) || (b.nc!=a.nc) ) {
-        ester_err("(matrix.min) Dimensions must agree");
-        exit(1);
+        ester_critical("(matrix.min) Dimensions must agree");
+        exit(1); // Useless because ester_critical already exit
     }
 
     matrix res(a.nf, a.nc);

--- a/src/matrix/matrix_block_diag.cpp
+++ b/src/matrix/matrix_block_diag.cpp
@@ -16,12 +16,10 @@ extern "C" {
 matrix_block_diag::matrix_block_diag(int nblocks) {
 
 	if(nblocks<0) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks can't be negative\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks can't be negative");
 	}
 	if(nblocks==0) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks can't be zero\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks can't be zero");
 	}
 	nb=nblocks;
 	m=new matrix[nb];
@@ -61,12 +59,10 @@ matrix_block_diag &matrix_block_diag::operator=(const matrix_block_diag &a) {
 matrix_block_diag & matrix_block_diag::set_nblocks(int nblocks) {
 
 	if(nblocks<0) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks can't be negative\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks can't be negative");
 	}
 	if(nblocks==0) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks can't be zero\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks can't be zero");
 	}
 
 	if(nblocks!=nb) {
@@ -102,8 +98,7 @@ matrix &matrix_block_diag::block(int i){
 
 	if(i<0) i+=nb;
 	if(i<0||i>=nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Index exceeds number of blocks\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Index exceeds number of blocks");
 	}
 	return m[i];
 	
@@ -113,8 +108,7 @@ const matrix &matrix_block_diag::block(int i) const {
 
 	if(i<0) i+=nb;
 	if(i<0||i>=nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Index exceeds number of blocks\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Index exceeds number of blocks");
 	}
 	return m[i];
 	
@@ -153,8 +147,7 @@ matrix matrix_block_diag::operator,(const matrix &a) const {
 	int i,n=0,n2=0;
 
 	if(ncols()!=a.nf) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Dimensions must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Dimensions must agree");
 	}
 	matrix res(nrows(),a.nc);
 
@@ -172,8 +165,7 @@ matrix_block_diag matrix_block_diag::operator,(const matrix_block_diag &a) const
 	matrix_block_diag res(nb);
 
 	if(nb!=a.nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks must agree");
 	}
 
 	for(i=0;i<nb;i++) res.m[i]=(m[i],a.m[i]);
@@ -188,8 +180,7 @@ matrix operator,(const matrix &a,const matrix_block_diag &b) {
 	unsigned n=0,n2=0;
 
 	if(a.ncols()!=b.nrows()) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Dimensions must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Dimensions must agree");
 	}
 	matrix res(a.nrows(),b.ncols());
 
@@ -209,8 +200,7 @@ matrix_block_diag matrix_block_diag::operator*(const matrix &z) const {
 	matrix zi;
 	
 	if((z.nc!=ncols()&&z.nc!=1)||(z.nf!=nrows()&&z.nf!=1)) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Dimensions must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Dimensions must agree");
 	}
 	
 	i=0;j=0;
@@ -234,8 +224,7 @@ matrix_block_diag matrix_block_diag::operator/(const matrix &z) const {
 	matrix zi;
 	
 	if((z.nc!=ncols()&&z.nc!=1)||(z.nf!=nrows()&&z.nf!=1)) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Dimensions must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Dimensions must agree");
 	}
 	
 	i=0;j=0;
@@ -283,8 +272,7 @@ matrix_block_diag matrix_block_diag::operator*(const matrix_block_diag &a) const
 	int i;
 
 	if(nb!=a.nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks must agree");
 	}
 
 	for(i=0;i<nb;i++) 
@@ -301,8 +289,7 @@ matrix_block_diag matrix_block_diag::operator+(const matrix_block_diag &a) const
 	int i;
 
 	if(nb!=a.nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks must agree");
 	}
 
 	for(i=0;i<nb;i++) 
@@ -319,8 +306,7 @@ matrix_block_diag matrix_block_diag::operator-(const matrix_block_diag &a) const
 	int i;
 
 	if(nb!=a.nb) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Number of blocks must agree\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Number of blocks must agree");
 	}
 
 	for(i=0;i<nb;i++) 
@@ -352,8 +338,7 @@ matrix matrix_block_diag::row(int n) const {
 	nf=nrows();
 	if(n<0) n+=nf;
 	if(n<0||n>=nf) {
-		fprintf(stderr,"ERROR: (matrix_block_diag.row) Index exceeds matrix dimensions\n");
-		exit(1);
+		ester_critical("(matrix_block_diag.row) Index exceeds matrix dimensions");
 	}
 	res=zeros(1,nf);
 	pres=res.p;
@@ -380,8 +365,7 @@ double matrix_block_diag::operator()(int nfil,int ncol) const {
 	if(nfil<0) nfil+=n;
 	if(ncol<0) ncol+=n;
 	if(nfil<0||nfil>=n||ncol<0||ncol>=n) {
-		fprintf(stderr,"ERROR: (matrix_block_diag) Index exceeds matrix dimensions\n");
-		exit(1);
+		ester_critical("(matrix_block_diag) Index exceeds matrix dimensions");
 	}
 	
 	int i=0,j=0;

--- a/src/matrix/matrix_block_diag.cpp
+++ b/src/matrix/matrix_block_diag.cpp
@@ -2,6 +2,7 @@
 #include "ester-config.h"
 #endif
 #include "matrix.h"
+#include "utils.h"
 
 extern "C" {
 #include <stdlib.h>

--- a/src/physics/atm_onelayer.cpp
+++ b/src/physics/atm_onelayer.cpp
@@ -38,8 +38,8 @@ int atm_onelayer(const matrix &X,double Z,const matrix &g,const matrix &Teff,
 			while(fin<2) {
 				nit++;
 				if(nit>100) {
-					ester_err("Error (atm_onelayer): No convergence");
-					return 1;
+					ester_critical("(atm_onelayer) No convergence");
+					return 1; // Useless because ester_critical already exit
 				}
 				double F,dF,dlogps;
 				p=pow(10,logps)*ones(1,1);

--- a/src/physics/eos_freeeos.cpp
+++ b/src/physics/eos_freeeos.cpp
@@ -123,7 +123,7 @@ int eos_freeeos(const matrix &X, double Z, const matrix &T, const matrix &p,
                 &iteration_count);
         rho(i) = rhoi;
         if (iteration_count < 0) {
-            ester_err(
+            ester_critical(
                     "Values outside freeEOS eos table:\n"
                     "  X = %e\n"
                     "  Z = %e\n"

--- a/src/physics/eos_opal.cpp
+++ b/src/physics/eos_opal.cpp
@@ -71,7 +71,7 @@ int eos_opal(const matrix &X,double Z,const matrix &T,const matrix &p,
     	eos.chi_rho(i)=*(eeos_.eos+5);
     	eos.chi_T(i)=*(eeos_.eos+6);
         if (fabs(rhoi - (-9e99)) < 1e-10) {
-            ester_err(
+            ester_critical(
                     "Values outside OPAL eos table:\n"
                     "  X = %e\n"
                     "  Z = %e\n"
@@ -80,8 +80,8 @@ int eos_opal(const matrix &X,double Z,const matrix &T,const matrix &p,
         }
     }
     if(exist(rho==-9e99)) {
-        ester_err("Values outside OPAL eos table");
-   		return 1;
+        ester_critical("Values outside OPAL eos table");
+        return 1; // Useless because ester_critical already exit
     }
 
     return 0;

--- a/src/physics/physics.cpp
+++ b/src/physics/physics.cpp
@@ -19,8 +19,8 @@ int opa_calc(const matrix &X,double Z,const matrix &T,const matrix &rho,
 	} else if(!strcmp(opa.name,"cesam")) {
 		error=opa_cesam(X, Z, T, rho, opa);
     } else {
-        ester_err("Unknown opacity method: %s",opa.name);
-    	return 1;
+        ester_critical("Unknown opacity method: %s", opa.name);
+        return 1; // Useless because ester_critical already exit
     }
 
 	return error;
@@ -40,8 +40,8 @@ int eos_calc(const matrix &X,double Z,const matrix &T,const matrix &p,
     else if(!strcmp(eos.name,"freeeos"))
         error = eos_freeeos(X, Z, T, p, rho, eos);
     else {
-        ester_err("Unknown equation of state: %s",eos.name);
-        return 1;
+        ester_critical("Unknown equation of state: %s", eos.name);
+        return 1; // Useless because ester_critical already exit
     }
 
     return error;
@@ -58,8 +58,8 @@ int nuc_calc(const matrix_map &X,const matrix &T,const matrix &rho,
 	} else if(!strcmp(nuc.name,"cesam")) {
 		error=nuc_cesam(X,T,rho,nuc);
     } else {
-        ester_err("Unknown nuc. reac. type: %s",nuc.name);
-    	return 1;
+        ester_critical("Unknown nuc. reac. type: %s", nuc.name);
+        return 1; // Useless because ester_critical already exit
     }
 
 	return error;
@@ -74,8 +74,8 @@ int atm_calc(const matrix &X,double Z,const matrix &g,const matrix &Teff,
 	if(!strcmp(atm.name,"onelayer")) {
 		error=atm_onelayer(X,Z,g,Teff,eos_name,opa_name,atm);
     } else {
-        ester_err("Unknown atmosphere type: %s", atm.name);
-    	return 1;
+        ester_critical("Unknown atmosphere type: %s", atm.name);
+        return 1; // Useless because ester_critical already exit
     }
 
 	return error;

--- a/src/solver/RKF_solver.cpp
+++ b/src/solver/RKF_solver.cpp
@@ -2,6 +2,7 @@
 #include "ester-config.h"
 #endif
 #include "solver.h"
+#include "utils.h"
 
 extern "C" {
 #include <string.h>

--- a/src/solver/RKF_solver.cpp
+++ b/src/solver/RKF_solver.cpp
@@ -65,8 +65,7 @@ void RKF_solver::destroy() {
 
 void RKF_solver::check_init() {
 	if(!initd) {
-		fprintf(stderr,"RKF_solver not initialized\n");
-		exit(1);
+		ester_critical("RKF_solver not initialized");
 	}
 }
 
@@ -77,13 +76,11 @@ void RKF_solver::regvar(const char *var_name,const matrix &initial_value) {
 	j=0;
 	while (strlen(var[j])) {
 		if(!strcmp(var[j],var_name)) {
-			fprintf(stderr,"ERROR: Can't register variable (already registered)\n");
-			exit(1);
+			ester_critical("(RKF_solver::regvar) Can't register variable (already registered)");
 		}
 		j++;
 		if(j==nv) {
-			fprintf(stderr,"ERROR: Can't register variable (increase nvar)\n");
-			exit(1);
+			ester_critical("(RKF_solver::regvar) Can't register variable (increase nvar)");
 		}
 	}	
 
@@ -114,8 +111,7 @@ int RKF_solver::get_id(const char *varn) {
 	while(strcmp(varn,var[i])||!reg[i]) {
 		i++;
 		if(i==nv) {
-			fprintf(stderr,"ERROR: Unknown variable %s\n",varn);
-			exit(1);
+			ester_critical("(RKF_solver::get_id) Unknown variable %s", varn);
 		}
 	}
 	return i;

--- a/src/solver/SDIRK_solver.cpp
+++ b/src/solver/SDIRK_solver.cpp
@@ -49,8 +49,7 @@ void SDIRK_solver::init(int nvar,const char *type) {
 	else if(!strcmp(type,"esdirk4"))
 		init_esdirk4();
 	else {
-		fprintf(stderr,"SDIRK_solver: Unknown RK method %s\n",type);
-		exit(1);
+		ester_critical("SDIRK_solver: Unknown RK method %s",type);
 	}
 	
 	check_method();
@@ -81,8 +80,7 @@ void SDIRK_solver::destroy() {
 
 void SDIRK_solver::check_init() {
 	if(!initd) {
-		fprintf(stderr,"SDIRK_solver not initialized\n");
-		exit(1);
+		ester_critical("SDIRK_solver not initialized");
 	}
 }
 
@@ -92,58 +90,48 @@ void SDIRK_solver::check_method() {
 	alpha=a(-1,-1);
 	
 	if(a.ncols()!=nstages) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (a is not square)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (a is not square)");
 	}
 	if(b.nrows()!=nstages) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (Incorrect size of vector b)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (Incorrect size of vector b)");
 	}
 	if(c.nrows()!=nstages) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (Incorrect size of vector c)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (Incorrect size of vector c)");
 	}
 	for(int i=0;i<nstages-1;i++) {
 		for(int j=i+1;j<nstages;j++) {
 			if(a(i,j)!=0) {
-				fprintf(stderr,"SDIRK_solver: Method is not diagonal implicit (a_ij!=0 for j>i)\n");
-				exit(1);
+				ester_critical("SDIRK_solver: Method is not diagonal implicit (a_ij!=0 for j>i)");
 			}
 		}
 	}
 	if(c(-1)!=1) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (c_n!=1)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (c_n!=1)");
 	}
 	if(exist(a.row(-1).transpose()!=b)) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (a_ni!=b_i)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (a_ni!=b_i)");
 	}
 	if(a(0,0)==0) {
 		first_explicit=true;
 		if(c(0)!=0) {
-			fprintf(stderr,"SDIRK_solver: Invalid method (c_1 should be 0 for an ESDIRK method)\n");
-			exit(1);
+			ester_critical("SDIRK_solver: Invalid method (c_1 should be 0 for an ESDIRK method)");
 		}
 	} else first_explicit=false;
 	
 	for(int i=0;i<nstages;i++) {
 		if(i==0&&first_explicit) continue;
 		if(a(i,i)!=alpha) {
-			fprintf(stderr,"SDIRK_solver: Invalid method (Diagonal terms in a are not equal)\n");
-			exit(1);
+			ester_critical("SDIRK_solver: Invalid method (Diagonal terms in a are not equal)");
 		}
 	}
 	
 	if(alpha==0) {
-		fprintf(stderr,"SDIRK_solver: Method is explicit\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Method is explicit");
 	}
 	
 	double tol=1e-14;
 	if(std::abs(sum(b)-1)>tol) {
-		fprintf(stderr,"SDIRK_solver: Invalid method (sum(b_i)!=1)\n");
-		exit(1);
+		ester_critical("SDIRK_solver: Invalid method (sum(b_i)!=1)");
 	}
 	order=1;
 	matrix T=c*eye(nstages);
@@ -179,13 +167,11 @@ void SDIRK_solver::regvar(const char *var_name,const matrix &initial_value) {
 	j=0;
 	while (strlen(var[j])) {
 		if(!strcmp(var[j],var_name)) {
-			fprintf(stderr,"ERROR: Can't register variable (already registered)\n");
-			exit(1);
+			ester_critical("Can't register variable (already registered)");
 		}
 		j++;
 		if(j==nv) {
-			fprintf(stderr,"ERROR: Can't register variable (increase nvar)\n");
-			exit(1);
+			ester_critical("Can't register variable (increase nvar)");
 		}
 	}	
 
@@ -242,8 +228,7 @@ int SDIRK_solver::get_id(const char *varn) {
 	while(strcmp(varn,var[i])||!reg[i]) {
 		i++;
 		if(i==nv) {
-			fprintf(stderr,"ERROR: Unknown variable %s\n",varn);
-			exit(1);
+			ester_critical("Unknown variable %s", varn);
 		}
 	}
 	return i;

--- a/src/solver/SDIRK_solver.cpp
+++ b/src/solver/SDIRK_solver.cpp
@@ -2,6 +2,7 @@
 #include "ester-config.h"
 #endif
 #include "solver.h"
+#include "utils.h"
 
 extern "C" {
 #include <string.h>

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -1362,7 +1362,7 @@ void solver::unwrap(const matrix *x,matrix *y) {
 		}
 		for(j=0;j<nv;j++) j0[j]+=n[i][j];
 	}
-    if (nan) ester_err("NaN values found in unwrap");
+    if (nan) ester_critical("(solver::unwrap) NaN values found in unwrap");
 }
 
 

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -1474,28 +1474,20 @@ void solver::add(int iblock,const char *eqn, const char *varn,const char *block_
 	ivar=get_id(varn);
 
 	if(dep(ieq)&&type!='d') {
-		fprintf(stderr,"ERROR (solver):\n\t");
-		fprintf(stderr,"Only type D terms are allowed in the definition of dependent variables\n");
-		fprintf(stderr,"\tin block %d, eq \"%s\", var \"%s\"\n",iblock,eqn,varn);
-		exit(1);
+		ester_critical("(solver::add) Only type D terms are allowed in the definition of dependent variables"
+					   " in block %d, eq '%s', var '%s'", iblock, eqn, varn);
 	}
 	if(dep(ieq)&&strcmp(block_type,"block")) {
-		fprintf(stderr,"ERROR (solver):\n\t");
-		fprintf(stderr,"No boundary conditions are allowed in the definition of dependent variables\n");
-		fprintf(stderr,"\tin block %d, eq \"%s\", var \"%s\"\n",iblock,eqn,varn);
-		exit(1);
+		ester_critical("(solver::add) No boundary conditions are allowed in the definition of dependent variables"
+					   " in block %d, eq '%s', var '%s'", iblock, eqn, varn);
 	}
 	if(iblock==0&&!strcmp(block_type,"bc_bot1")) {
-		fprintf(stderr,"ERROR (solver):\n\t");
-		fprintf(stderr,"\"bc_bot1\" terms are not allowed in first domain\n");
-		fprintf(stderr,"\tin block %d, eq \"%s\", var \"%s\"\n",iblock,eqn,varn);
-		exit(1);
+		ester_critical("(solver::add) 'bc_bot1' terms are not allowed in first domain"
+					   " in block %d, eq '%s', var '%s'", iblock, eqn, varn);
 	}
 	if(iblock==nb-1&&!strcmp(block_type,"bc_top2")) {
-		fprintf(stderr,"ERROR (solver):\n\t");
-		fprintf(stderr,"\"bc_top2\" terms are not allowed in last domain\n");
-		fprintf(stderr,"\tin block %d, eq \"%s\", var \"%s\"\n",iblock,eqn,varn);
-		exit(1);
+		ester_critical("(solver::add) 'bc_top2' terms are not allowed in last domain"
+					   " in block %d, eq '%s', var '%s'", iblock, eqn, varn);
 	}
 
 	sync=0;
@@ -1514,8 +1506,7 @@ void solver::add(int iblock,const char *eqn, const char *varn,const char *block_
 	else if(!strcmp(block_type,"bc_top2"))
 		bb=bc_top2;
 	else {
-		fprintf(stderr,"ERROR (solver::add) : Unknown block_type %s\n",block_type);
-		exit(1);
+		ester_critical("(solver::add) : Unknown block_type %s", block_type);
 	}
 
 	matrix *ll,L;
@@ -1626,8 +1617,8 @@ int solver::check_struct() {
 				Nt=nth[n][i]>Nt?nth[n][i]:Nt;
 			}
 			if(rhs[i].nrows()!=Nr||rhs[i].ncols()!=Nt) {
-				fprintf(stderr,"ERROR (solver):\n\tRHS for var \"%s\" has not the correct size\n",var[i]);
-				fprintf(stderr,"\tIt is (%d,%d) and should be (%d,%d)\n",rhs[i].nrows(),rhs[i].ncols(),Nr,Nt);
+				ester_err("(solver) RHS for var '%s' has not the correct size\n"
+						  "\t It is (%d,%d) and should be (%d,%d)", var[i], rhs[i].nrows(), rhs[i].ncols(), Nr, Nt);
 				error=1;
 			}
 		}
@@ -1922,8 +1913,7 @@ void solver::subst_dep() {
 			substd=0;
 			for(int i=0;i<nv;i++) {
 				if(dep(i)&&block[n].eq[i][i]!=NULL) {
-					fprintf(stderr,"ERROR (solver):\n\tFound loop in definition of dependent variable \"%s\"\n",var[i]);
-					exit(1);
+					ester_critical("(solver::subst_dep) Found loop in definition of dependent variable '%s'", var[i]);
 				}
 			}
 			for(int i=0;i<nv;i++) {
@@ -2111,10 +2101,7 @@ void solver::subst_dep_elem(int i,int k,solver_block *bb,solver_elem *p,const ma
             }
             break;
         default:
-            fprintf(stderr,
-                    "Error in solver::subst_dep_elem: unknown type (%c)\n",
-                    p->type);
-            exit(EXIT_FAILURE);
+            ester_critical("(solver::subst_dep_elem) unknown type (%c)", p->type);
     }
 
 	bb->add(i,k,type_new,&D,&L,&R,&I);

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -1871,31 +1871,30 @@ int solver::check_struct_bc(int n,int i,int j,const char *bctype) {
 
 
 void solver::check_struct_error(const char *err_msg,int n,int i,int j,solver_elem *p) {
-
-	fprintf(stderr,"ERROR (solver):\n\t%s\n\tin block %d, eq \"%s\", var \"%s\"",err_msg,n,var[i],var[j]);
+	char type_name[4];
 	switch(p->type) {
 		case 'd':
-			fprintf(stderr," (type: d)\n");
+			strncpy(type_name, "d", sizeof(type_name));
 			break;
 		case 'l':
-			fprintf(stderr," (type: l)\n");
+			strncpy(type_name, "l", sizeof(type_name));
 			break;
 		case 'r':
-			fprintf(stderr," (type: r)\n");
+			strncpy(type_name, "r", sizeof(type_name));
 			break;
 		case 'f':
-			fprintf(stderr," (type: lr)\n");
+			strncpy(type_name, "lr", sizeof(type_name));
 			break;
 		case 'm':
-			fprintf(stderr," (type: li)\n");
+			strncpy(type_name, "li", sizeof(type_name));
 			break;
 		case 's':
-			fprintf(stderr," (type: ri)\n");
+			strncpy(type_name, "ri", sizeof(type_name));
 			break;
 		case 'g':
-			fprintf(stderr," (type: lri)\n");
+			strncpy(type_name, "lri", sizeof(type_name));
 	}
-
+	ester_err("(solver::check_struct_error) '%s' in block %d, eq: '%s', var: '%s' (type: %s)", err_msg, n, var[i], var[j], type_name);
 }
 
 /// \brief Substitutes dependent variables defined in the solver.

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -1325,7 +1325,7 @@ void solver::unwrap(const matrix *x,matrix *y) {
 				q.redim(nth[i][j],nbot[i][j]);
 				y[j].setblock(j0[j],j0[j]+nbot[i][j]-1,0,nth[i][j]-1,q.transpose());
                 if (std::isnan(max(abs(q)))) {
-                    LOGE("var %8s (%2dx%2d), block %d (bc_bot): NaN\n", var[j],
+                    ester_err("var %8s (%2dx%2d), block %d (bc_bot): NaN", var[j],
                             nth[i][j], nbot[i][j], i);
                     nan = true;
                 }
@@ -1340,7 +1340,7 @@ void solver::unwrap(const matrix *x,matrix *y) {
 				q.redim(nth[i][j],nn);
 				y[j].setblock(j0[j]+nbot[i][j],j0[j]+nbot[i][j]+nn-1,0,nth[i][j]-1,q.transpose());
                 if (std::isnan(max(abs(q)))) {
-                    LOGE("var %8s (%2dx%2d), block %d (eq): NaN\n", var[j],
+                    ester_err("var %8s (%2dx%2d), block %d (eq): NaN", var[j],
                             nth[i][j], nn, i);
                     nan = true;
                 }
@@ -1354,7 +1354,7 @@ void solver::unwrap(const matrix *x,matrix *y) {
 				q.redim(nth[i][j],ntop[i][j]);
 				y[j].setblock(j0[j]+n[i][j]-ntop[i][j],j0[j]+n[i][j]-1,0,nth[i][j]-1,q.transpose());
                 if (std::isnan(max(abs(q)))) {
-                    LOGE("var %8s (%2dx%2d), block %d (bc_top): NaN\n", var[j],
+                    ester_err("var %8s (%2dx%2d), block %d (bc_top): NaN", var[j],
                             nth[i][j], ntop[i][j], i);
                     nan = true;
                 }

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -1434,31 +1434,31 @@ void solver::add(const char *eqn, const char *varn,const char *block_type,char t
 	}
 
 	if(error) {
-		ester_err("ERROR (solver):\n\t%s\n\tin eq \"%s\", var \"%s\"",
-                err_msg,eqn,varn);
+		char type_name[4];
 		switch(type) {
 			case 'd':
-				ester_err(" (type: d)");
+				strncpy(type_name, "d", sizeof(type_name));
 				break;
 			case 'l':
-				ester_err(" (type: l)");
+				strncpy(type_name, "l", sizeof(type_name));
 				break;
 			case 'r':
-				ester_err(" (type: r)");
+				strncpy(type_name, "r", sizeof(type_name));
 				break;
 			case 'f':
-				ester_err(" (type: lr)");
+				strncpy(type_name, "lr", sizeof(type_name));
 				break;
 			case 'm':
-				ester_err(" (type: li)");
+				strncpy(type_name, "li", sizeof(type_name));
 				break;
 			case 's':
-				ester_err(" (type: ri)");
+				strncpy(type_name, "ri", sizeof(type_name));
 				break;
 			case 'g':
-				ester_err(" (type: lri)");
+				strncpy(type_name, "lri", sizeof(type_name));
 		}
-		exit(1);
+		ester_critical("(solver::add) '%s' in eq '%s', var: '%s' (type: %s)", err_msg, eqn, varn, type_name);
+		exit(1); // Useless because ester_critical already exit
 	}
 	delete dd;
 	if(type=='m'||type=='s'||type=='g') delete ii;

--- a/src/solver/solver.cpp
+++ b/src/solver/solver.cpp
@@ -281,13 +281,13 @@ void solver::regvar(const char *var_name,int dependent) {
 	j=0;
 	while (strlen(var[j])) {
 		if(!strcmp(var[j],var_name)) {
-			ester_err("ERROR: Can't register variable (already registered)");
-			exit(1);
+			ester_critical("(solver::regvar) Can't register variable (already registered)");
+			exit(1); // Useless because ester_critical already exit
 		}
 		j++;
 		if(j==nv) {
-			ester_err("ERROR: Can't register variable (increase nvar)");
-			exit(1);
+			ester_critical("(solver::regvar) Can't register variable (increase nvar)");
+			exit(1); // Useless because ester_critical already exit
 		}
 	}
 
@@ -317,8 +317,8 @@ int solver::get_id(const char *varn) {
 	while(strcmp(varn,var[i])||!reg(i)) {
 		i++;
 		if(i==nv) {
-			ester_err("ERROR: Unknown variable %s", varn);
-			exit(1);
+			ester_critical("(solver::get_id) Unknown variable %s", varn);
+			exit(1); // Useless because ester_critical already exit
 		}
 	}
 	return i;
@@ -349,10 +349,8 @@ void solver::set_rhs(const char *eqn,const matrix &b) {
 	int ieq;
 	ieq=get_id(eqn);
 	if(dep(ieq)) {
-		ester_err("ERROR (solver):\n\t");
-		ester_err("RHS not used in the definition of dependent variable \"%s\"",
-                eqn);
-        std::exit(EXIT_FAILURE);
+		ester_critical("(solver::set_rhs) RHS not used in the definition of dependent variable '%s'", eqn);
+        std::exit(EXIT_FAILURE); // Useless because ester_critical already exit
 	}
 
 	rhs[ieq]=b;
@@ -409,7 +407,7 @@ void solver::solve(int *info) {
     if(verbose)
         printf("Checking structure...\n");
     err=check_struct();
-    if(err&2) exit(1);
+    if(err&2) ester_critical("(solver::solve) check_struct returned an error");
     if(err) struct_changed=1;
     if(verbose)
         printf("Substitution of dependent variables...\n");
@@ -856,8 +854,8 @@ void solver::create() {
 	} else if(!strcmp(type,"iter")) {
 		op=new solver_iter();
 	} else {
-		ester_err("Unknown solver type \"%s\"", type);
-		exit(1);
+		ester_critical("Unknown solver type \"%s\"", type);
+		exit(1); // Useless because ester_critical already exit
 	}
 	op->verbose=verbose;
 
@@ -1384,7 +1382,7 @@ void solver::add(const char *eqn, const char *varn,const char *block_type,char t
 	else ii=NULL;
 	j0=0;
 	if(strcmp(block_type,"block")&&strcmp(block_type,"bc_eq")&&strcmp(block_type,"bc_pol")) {
-		ester_err("(solver::add): Invalid block_type %s", block_type);
+		ester_critical("(solver::add) Invalid block_type %s", block_type);
 	}
 
 	for(k=0;k<nb;k++) {

--- a/src/solver/solver_full.cpp
+++ b/src/solver/solver_full.cpp
@@ -44,8 +44,7 @@ solver_full::solver_full(int nblocks,int offcore) {
 	if(oc) {
 		sprintf(tempdir,"solver_full_oc_tmp_XXXXXX");
 		if (mkdtemp(tempdir) == NULL)
-            ester_err("could not create temporary directory `%s'",
-                    tempdir);
+            ester_critical("could not create temporary directory '%s'", tempdir);
 	}
 
 }
@@ -244,7 +243,7 @@ void solver_full::solve_block(int i,char trans,matrix &x) {
 	else x=x*r[i];
 
     if (std::isnan(max(abs(x)))) {
-        ester_err("NaN in RHS solve block %d\n", i);
+        ester_critical("NaN in RHS solve block %d", i);
     }
 	
 	n=m[i].nrows();nrhs=x.ncols();
@@ -256,7 +255,7 @@ void solver_full::solve_block(int i,char trans,matrix &x) {
             if (std::isnan(xx(ii)))
                 LOGE("rhs(%3d) = %e\n", ii, xx(ii));
         }
-        ester_err("NaN found in solve_block");
+        ester_critical("(solver_full::solve_block) NaN found in solve_block");
     }
 
 

--- a/src/solver/solver_full.cpp
+++ b/src/solver/solver_full.cpp
@@ -250,10 +250,10 @@ void solver_full::solve_block(int i,char trans,matrix &x) {
 	dgetrs_(&trans,&n,&nrhs,m[i].data(),&n,ipiv[i],x.data(),&n,&info);
 
     if (std::isnan(max(abs(x)))) {
-        LOGE("NaN in solve block %d\n", i);
+        ester_err("NaN in solve block %d", i);
         for (int ii=0; ii<xx.ncols()*xx.nrows(); ii++) {
             if (std::isnan(xx(ii)))
-                LOGE("rhs(%3d) = %e\n", ii, xx(ii));
+                ester_err("rhs(%3d) = %e", ii, xx(ii));
         }
         ester_critical("(solver_full::solve_block) NaN found in solve_block");
     }

--- a/src/star/polytrope.cpp
+++ b/src/star/polytrope.cpp
@@ -3,6 +3,8 @@
 
 #include <cstdlib>
 
+#define MAX_POLYTROPE_ITER 10000
+
 matrix solve_poly1d(double n, double tol, int nr, double hsurf) {
     // Create a mapping
     printf("parametres: n = %e tol %e, nr %d, hsurf %e\n",n,tol,nr,hsurf);
@@ -50,7 +52,7 @@ matrix solve_poly1d(double n, double tol, int nr, double hsurf) {
     op.regvar("Phi0");
     op.set_nr(map.npts);
 
-    while(error>tol && it<10000) {
+    while(error>tol && it < MAX_POLYTROPE_ITER) {
         // Put the current values of variables in the symbolic object
         S.set_value("Phi", Phi);
         S.set_value("Lambda", Lambda*ones(1, 1)); // Note that the assigned value should be of type matrix
@@ -109,7 +111,7 @@ matrix solve_poly1d(double n, double tol, int nr, double hsurf) {
     }
 
     if(error>tol) {
-        ester_err("No converge\n");
+        ester_critical("(solve_poly1d) No convergence after %d iterations", MAX_POLYTROPE_ITER);
     }
 
     matrix h = 1.0 - (Phi - Phi(0))*Lambda;
@@ -128,7 +130,7 @@ matrix solve_poly1d(double n, double tol, int nr, double hsurf) {
         dhi = map.gl.eval(dh, ri)(0);
     }
     if (nit >= maxit) {
-        ester_err("No convergence finding polytrope surface such that h(surface) = %e", hsurf);
+        ester_critical("(solve_poly1d) No convergence finding polytrope surface such that h(surface) = %e", hsurf);
     }
 
     matrix h2 = map.gl.eval(h, map.r*ri);

--- a/src/star/star1d_extra.cpp
+++ b/src/star/star1d_extra.cpp
@@ -47,7 +47,7 @@ matrix star1d::Teff() const {
 	F=-opa.xi*(D,T);
     matrix teff = pow(F(-1)/SIG_SB*units.T/units.r,0.25)*ones(1,1);
     if (std::isnan(teff(0))) {
-        ester_err("Teff is NaN (D,T) = %e", (D,T)(-1));
+        ester_critical("Teff is NaN (D,T) = %e", (D,T)(-1));
     }
 	return teff;
 

--- a/src/star/star2d_class.cpp
+++ b/src/star/star2d_class.cpp
@@ -257,7 +257,7 @@ void star2d::write(const char *output_file) const {
         hdf5_write(output_file);
         return;
     }
-    ester_err("The output file %s is not HDF5 format.", output_file);
+    ester_critical("The output file %s is not HDF5 format.", output_file);
 }
 
 template<typename T>
@@ -300,19 +300,19 @@ int star2d::hdf5_read(const char *input_file, int dim) {
         file = H5::H5File(input_file, H5F_ACC_RDONLY);
     }
     catch (H5::FileIException e) {
-        ester_err("Could not open file `%s'", input_file);
+        ester_critical("Could not open file `%s'", input_file);
     }
     H5::Group star;
     try {
         star = file.openGroup("/star");
     }
     catch (H5::Exception) {
-        ester_err("Could not open '/star' in `%s'", input_file);
+        ester_critical("Could not open '/star' in `%s'", input_file);
     }
 
     int ndoms;
     if (read_attr(star, "nth", &map.leg.npts)) {
-        ester_err("could not read 'nth' from file `%s'", input_file);
+        ester_critical("could not read 'nth' from file `%s'", input_file);
     }
     if ((map.leg.npts == 1 && dim == 2) || (map.leg.npts > 1 && dim == 1)) {
         return 1;
@@ -323,21 +323,21 @@ int star2d::hdf5_read(const char *input_file, int dim) {
     }
     version.name = buf;
     if (read_attr(star, "ndomains", &ndoms)) {
-        ester_err("Could not read 'ndomains' from file `%s'", input_file);
-        exit(EXIT_FAILURE);
+        ester_critical("Could not read 'ndomains' from file `%s'", input_file);
+        exit(EXIT_FAILURE); // Useless because ester_critical already exit
     }
     map.gl.set_ndomains(ndoms);
     if (read_attr(star, "npts", map.gl.npts)) {
-        ester_err("Could not read 'npts' from file `%s'", input_file);
-        exit(EXIT_FAILURE);
+        ester_critical("Could not read 'npts' from file `%s'", input_file);
+        exit(EXIT_FAILURE); // Useless because ester_critical already exit
     }
     if (read_attr(star, "xif", &map.gl.xif[0])) {
-        ester_err("Could not read 'xif' from file `%s'", input_file);
-        exit(EXIT_FAILURE);
+        ester_critical("Could not read 'xif' from file `%s'", input_file);
+        exit(EXIT_FAILURE); // Useless because ester_critical already exit
     }
     if (read_attr(star, "nex", map.ex.gl.npts)) {
-        ester_err("Could not read 'nex' from file `%s'", input_file);
-        exit(EXIT_FAILURE);
+        ester_critical("Could not read 'nex' from file `%s'", input_file);
+        exit(EXIT_FAILURE); // Useless because ester_critical already exit
     }
     if (read_attr(star, "M", &M)) {
         ester_warn("Could not read 'M' from file `%s'", input_file);
@@ -355,8 +355,8 @@ int star2d::hdf5_read(const char *input_file, int dim) {
         ester_warn("Could not read 'Xc' from file `%s'", input_file);
     }
     if (read_attr(star, "conv", &conv)) {
-        ester_err("Could not read 'conv' from file `%s'", input_file);
-        exit(EXIT_FAILURE);
+        ester_critical("Could not read 'conv' from file `%s'", input_file);
+        exit(EXIT_FAILURE); // Useless because ester_critical already exit
     }
 
     domain_type.resize(ndomains);
@@ -439,20 +439,20 @@ int star2d::hdf5_read(const char *input_file, int dim) {
     map.init();
 
     if (read_field(star, "phi", phi)) {
-        ester_err("Could not read field 'phi' from file `%s'", input_file);
+        ester_critical("Could not read field 'phi' from file `%s'", input_file);
     }
     if (read_field(star, "p", p)) {
-        ester_err("Could not read field 'p' from file `%s'", input_file);
+        ester_critical("Could not read field 'p' from file `%s'", input_file);
     }
     if (read_field(star, "T", T)) {
-        ester_err("Could not read field 'T' from file `%s'", input_file);
+        ester_critical("Could not read field 'T' from file `%s'", input_file);
     }
     if (read_field(star, "phiex", phiex)) {
         ester_warn("Could not read field 'phiex' from file `%s'", input_file);
         phiex = zeros(nr, nth);
     }
     if (read_field(star, "R", map.R)) {
-        ester_err("Could not read field 'R' from file `%s'", input_file);
+        ester_critical("Could not read field 'R' from file `%s'", input_file);
     }
     if (map.R.nrows() < map.ndomains+1)
         map.R = zeros(1,nth).concatenate(map.R);
@@ -480,7 +480,7 @@ int star2d::read(const char *input_file, int dim) {
     if (isHDF5Name(input_file)) {
         return hdf5_read(input_file, dim);
     }
-    ester_err("The input file %s is not HDF5 format.", input_file);
+    ester_critical("The input file %s is not HDF5 format.", input_file);
 }
 
 bool star2d::check_tag(const char *tag) const {
@@ -674,8 +674,8 @@ int star2d::check_arg(char *arg,char *val,int *change_grid) {
         map.gl.set_ndomains(atoi(val));
         *change_grid=*change_grid|1;
         if(*change_grid&2) {
-            ester_err("ndomains must be specified before npts\n");
-            exit(1);
+            ester_critical("(star2d::check_arg) ndomains must be specified before npts");
+            exit(1); // Useless because ester_critical already exit
         }
     }
     else if(!strcmp(arg,"npts")) {
@@ -721,7 +721,7 @@ int star2d::check_arg(char *arg,char *val,int *change_grid) {
         Xc=atof(val);
     }
     else if(!strcmp(arg,"conv")) {
-        ester_err("Param. conv is no longer modifiable. Disable core convection with core_convec 0.\n");
+        ester_err("Param. conv is no longer modifiable. Disable core convection with core_convec 0.");
         return 1;
     }
     else if(!strcmp(arg,"surff")) {

--- a/src/star/star_map.cpp
+++ b/src/star/star_map.cpp
@@ -401,7 +401,7 @@ int star2d::check_convec(double &p_cc,matrix &Rcc) {
 
     if(config.verbose) printf("Found convective core\n");
     if(ndomains==1) {
-        fprintf(stderr,"Warning: At least 2 domains are needed to deal with core convection\n");
+        ester_warn("At least 2 domains are needed to deal with core convection");
     }
 
     while(schw(i,-1)<0) i++; // look for change of sign of schw

--- a/src/star/star_map.cpp
+++ b/src/star/star_map.cpp
@@ -98,7 +98,7 @@ std::vector<int> star2d::distribute_domains(int ndom,matrix &zif,bool check_only
     int nzones=zif.nrows();
 
     if(nzones>ndom) {
-        ester_err("Error: At least %d domains are needed for this model\n",nzones);
+        ester_critical("At least %d domains are needed for this model", nzones);
     }
 
     // Calculate Delta(log(T)) in each zone at theta=0
@@ -224,7 +224,7 @@ matrix star2d::find_boundaries(const matrix &logTi) const {
                 }
                 LOGE("No convergence in find_boundaries");
                 plt::show(true);
-                ester_err("No convergence in find_boundaries\n");
+                ester_critical("(star2d::find_boundaries) No convergence");
             }
         }
         zi.setcol(j,zj);
@@ -309,7 +309,7 @@ matrix star2d::find_boundaries_old(matrix pif) const {
             zj+=dzj;
             nit++;
             if(nit>100) {
-                ester_err("No convergence in find_boundaries\n");
+                ester_critical("(star2d::find_boundaries_old) No convergence");
             }
         }
 

--- a/src/star/star_map.cpp
+++ b/src/star/star_map.cpp
@@ -220,9 +220,8 @@ matrix star2d::find_boundaries(const matrix &logTi) const {
                 for (int i=0; i<logTi.nrows(); i++) {
                     plt::axvline(zj(i));
                     plt::axhline(logTi(i));
-                    LOGE("ri%d zj=%e, dzj=%e\n", i, zj(i), dzj(i));
+                    ester_err("ri%d zj=%e, dzj=%e", i, zj(i), dzj(i));
                 }
-                LOGE("No convergence in find_boundaries");
                 plt::show(true);
                 ester_critical("(star2d::find_boundaries) No convergence");
             }

--- a/src/symbolic/sym.cpp
+++ b/src/symbolic/sym.cpp
@@ -254,12 +254,12 @@ sym diff(const sym &f,const sym &x) {
 		}
 	}
 
-	ester_err("Error (symbolic): Can derive only respect to independent symbols");
+	ester_critical("(symbolic) Can derive only respect to independent symbols");
 }
 sym jacobian(const sym &f,const sym &a) {
 
 	if(typeid(*a.expr)!=typeid(sym::symbol)&&typeid(*a.expr)!=typeid(sym::sym_deriv)) {
-		ester_err("Error (symbolic): Can calculate jacobian only with respect to a symbol or a derivative of a symbol");
+		ester_critical("(symbolic) Can calculate jacobian only with respect to a symbol or a derivative of a symbol");
 	}
 
 	sym snew;

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -89,7 +89,7 @@ int debugger::eval(const std::string& _cmd) {
     }
     else if (cmd == "plot") {
         if (args.size() < 2) {
-            LOGE("Missong argument to command `%s\'\n", args[0].c_str());
+            ester_err("Missong argument to command `%s\'", args[0].c_str());
             return 1;
         }
         std::string var = args[1];
@@ -105,7 +105,7 @@ int debugger::eval(const std::string& _cmd) {
     }
     else if (cmd == "spectrum") {
         if (args.size() < 2) {
-            LOGE("Missing argument to command `%s\'\n", args[0].c_str());
+            ester_err("Missing argument to command `%s\'", args[0].c_str());
             return 1;
         }
         std::string var = args[1];
@@ -117,7 +117,7 @@ int debugger::eval(const std::string& _cmd) {
     else if (cmd == "") {
     }
     else {
-        LOGE("Unknown command `%s\'\n", cmd.c_str());
+        ester_err("Unknown command `%s\'", cmd.c_str());
     }
     return 1;
 }
@@ -129,7 +129,7 @@ matrix debugger::get_var(const std::string& var) {
     if (var == "D,rho") return (star.D,star.rho);
     if (var == "D,T") return (star.D,star.T);
     if (var == "D,p") return (star.D,star.p);
-    LOGE("Unknown varaible `%s\'\n", var.c_str());
+    ester_err("Unknown varaible `%s\'", var.c_str());
     return zeros(1, 1);
 }
 

--- a/src/utils/debug.cpp
+++ b/src/utils/debug.cpp
@@ -12,7 +12,7 @@
 
 
 void sigfpe_handler(int) {
-    ester_err("SIGFPE");
+    ester_critical("SIGFPE");
 }
 
 void enable_sigfpe() {


### PR DESCRIPTION
## Motivations
A good logging tool/system is very useful to both the programmer and the user

ESTER already had the shape of one but two macros was co-existing `ester_*` and `LOG*`  
Also in several places of the codebase `fprintf(stderr, ...)` was used, bypassing the logging tools, probably because the programmer didn't know of its existence.

## Problems and ambiguous situtations
`ester_err` was used, but often the next line was `exit(1)` while `exit(EXIT_FAILURE)` was already included in the macro making it useless and showing the lack of knowledge around the macro.  
But more importantly this misusage of the macro raised doubts about the cases where `ester_err` was used but the function continued afterwards, code that will not be executed because `ester_err` embed an `exit` call, I noticed such ambiguous use in these files:
- `atm_onelayer.cpp`
- `physics.cpp`

These cases were more difficult to dealt with when replacing old calls with new one because even if it was useless we knew that ESTER run well as it is: 
- should I replace them with new `ester_err` which doesn't exit but risk the appearance of new bugs?
- or should I ignore this issue and replace them with new `ester_critical` keeping the same behavior as before

## New macros proposal

`ester_debug`:
- print to stderr in DEBUG
- none else

`ester_debug`:
- prefixed with green "Info"
- print to stdout in both modes

`ester_warn`:
- prefixed with yellow "Warning:"
- print to stderr 
  \+ indicate line and file in DEBUG

`ester_err`:
- **same as `ester_warn`** with red "Error:"
 \+ print stack in DEBUG

`ester_critical`:
- **same as `ester_err`** with red "CRITICAL:"
 \+ exit program or throw exception


## Changes to the code

- No `LOGI` nor `LOGW` were used
- obvious `ester_err` (the ones that obviously want to exit directly) have been replaced by `ester_critical` keeping the same behavior
- a comment has been added, exactly: `// Useless because ester_critical already exit` on useless `exit()` calls or `return` that won't ever be reached
- in other ambiguous places: `solver.cpp`, `atm_onelayer.cpp`, `physics.cpp`, `polytrope.cpp`, `eos_freeeos.cpp`, `eos_opal.cpp` I prefered to replace by `ester_critical` keeping the same behavior as before but each of these case could be debated to let the function return and above function read an error code and exit themselves
- in `star2d::init` the choice has been made to let the function return 1 and let the program exit via `ester_critical` in `star2d.cpp:main` --> see [Future changes](#future-changes)
- in `star1d::init` few changes were made contrary to `star2d::init` hence the need of a future homogenization
- in `solver.cpp` 



## Roadmap

refactor le logging:
- [X] update les macros de logging
- [X] Rendre moins moche le print: le log level en couleur le reste en blanc
- [X] remplacer les ester_err par ester_err ou ester_critical et formatter
- [X] remplacer les LOGE par ester_err et formatter
- [X] tester
- [X] remplacer les fprintf to stderr par ester_err /critical: `stat_evol.cpp`, `mat_math.cpp`, `matrix_block_diag.cpp`, `matrix.cpp`, `RFK_solver.cpp`, `SDIRK_solver.cpp`, `solver_full.cpp`, `solver.cpp`, `star_map.cpp`, `star1d_class.cpp`
- [X] dans `solver.cpp` on a solver::add qui implemente un switch(type) qui semble redondant avec ce que fait solver::check_struct_error, voir si il faut factoriser du code --> reponse: NON
- [X] remplacer tous les printf/fprintf par du logging SI POSSIBLE
- [X] tester

## Future changes
Laisser pour de futures PR:
- In `star1d::init`, `star2d::init`, `read_config.cpp`, `parser.cpp`, `star1d.cpp`, `star2d.cpp`:
  - Use new logging macros
  - Homogenize and comment parsing and configuration
  - Improve logic: let appropriate function return and higher level ones, as `main`, exit with `ester_critical`
- All `printf("error ...")` should be replaced as `fprintf(stderr, ..)` has been but this could be more difficult (to check each printf call)



