### PR TITLE
Fix frontpage header HTML rendering (removing git merging artifact).

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,7 @@
                 <h1 id="project_title">ESTER</h1>
                 <h2 id="project_tagline">Evolution STEllaire en Rotation</h2>
 
-<<<<<<< HEAD
-                <section id="downloads">
-=======
                 <!--<section id="downloads">
->>>>>>> e5394674a26322150f8514cb92112d28771e644f
                     <a class="zip_download_link"
                         href="download/ester-1.2.0rc1.zip">
                         Download this project as a .zip file


### PR DESCRIPTION
Reading [ESTER's doc](http://ester-project.github.io/ester/) I noticed this HTML rendering minor error due to git manipulations:

![image](https://github.com/user-attachments/assets/30af5255-494c-4c13-8f12-af6e686289d1)
(there is a "HEAD"  git expression in the header that shouldn't be here)

After the minor fix I propose in this PR the rendering is correct:
![image](https://github.com/user-attachments/assets/bfa2b1d3-f847-4d9d-b14f-00f4671e3399)
(no more "HEAD" in the header).

Best regards.

Hakim Hadj-djilani